### PR TITLE
feat: Add command for updating the `.sql` file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+help:
+	@echo "Usage: make [command]"
+	@echo ""
+	@echo "help      – Show this help"
+	@echo "up        – Start the mysql container locally"
+	@echo "down      – Stop the mysql container"
+
 up:
 	docker compose up --detach
 

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,16 @@ help:
 	@echo "help      – Show this help"
 	@echo "up        – Start the mysql container locally"
 	@echo "down      – Stop the mysql container"
+	@echo "dump      – Dump to the local `.sql` file"
 
 up:
 	docker compose up --detach
 
 down:
 	docker compose down
+
+dump:
+	docker compose exec -T mysql mysqldump --user=root --password=secret \
+		--lock-all-tables --complete-insert --skip-extended-insert \
+		--comments --skip-dump-date --default-character-set=utf8 \
+		--databases serlo > docker-entrypoint-initdb.d/001-init.sql

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+up:
+	docker compose up --detach
+
+down:
+	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+
+services:
+  mysql:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    platform: linux/x86_64
+    ports:
+      - '3306:3306'


### PR DESCRIPTION
After moving the `.sql` file to this repository, the `yarn mysql:dump` does not make any sense any more. I have added a command to update the mysql file inside this repository.