### PR TITLE
feat(docker): Remove cache after installing `pv`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM mysql:8.0.31-debian
-RUN apt update && apt install -y pv
+RUN apt-get update && apt-get install -y --no-install-recommends pv \
+    # Clean up the apt cache by removing /var/lib/apt/lists
+    && rm -rf /var/lib/apt/lists/* \
+    # Clear out the local repository of retrieved package files
+    && apt-get clean
 COPY docker-entrypoint-initdb.d /docker-entrypoint-initdb.d
 COPY conf.d/mysqld.cnf /etc/mysql/conf.d
 # The entrypoint script will not run when `serlo.cnf` is in /etc/mysql/conf.d


### PR DESCRIPTION
It reduces the container size by `18MB` -> Not much, but it is something